### PR TITLE
Allow up to 2048 MB in the RAM selector

### DIFF
--- a/limbo-android-lib/src/main/java/com/max2idea/android/limbo/main/LimboActivity.java
+++ b/limbo-android-lib/src/main/java/com/max2idea/android/limbo/main/LimboActivity.java
@@ -3749,7 +3749,7 @@ public class LimboActivity extends AppCompatActivity {
 	// Set Hard Disk
 	private void populateRAM() {
 
-		String[] arraySpinner = new String[128];
+		String[] arraySpinner = new String[256];
 
 		arraySpinner[0] = 4 + "";
 		for (int i = 1; i < arraySpinner.length; i++) {


### PR DESCRIPTION
New phones come out with octacore processors and more than 6 GB of RAM, this will allow users to select more than 1GB of RAM 