### PR TITLE
Please make ARMv7 version 5.1 with signalfd=no

### DIFF
--- a/limbo-android-lib/src/main/jni/patches/qemu-5.1.0.patch
+++ b/limbo-android-lib/src/main/jni/patches/qemu-5.1.0.patch
@@ -83,7 +83,17 @@ diff -ru --no-dereference /tmp/qemu-5.1.0/configure ./configure
  fi
  
  ##########################################
-@@ -5526,7 +5535,8 @@
+@@ -4554,4 +4563,9 @@
+ signalfd=yes
+ fi
+
++#Limbo: Android x86_64 devices (at least emulator images)
++# have the headers but don't support SYS_signalfd
++# fortunately there is qemu_compat_signalfd
++signalfd=no
++
+ # check if eventfd is supported# check if optreset global is declared by <getopt.h>
+@@ -5531,7 +5540,8 @@
  int main(void) { return strchrnul(haystack, 'x') != &haystack[6]; }
  EOF
  if compile_prog "" "" ; then
@@ -93,7 +103,7 @@ diff -ru --no-dereference /tmp/qemu-5.1.0/configure ./configure
  fi
  
  #########################################
-@@ -6066,6 +6076,7 @@
+@@ -6071,6 +6081,7 @@
  ###############################################
  # Check if copy_file_range is provided by glibc
  have_copy_file_range=no
@@ -101,7 +111,7 @@ diff -ru --no-dereference /tmp/qemu-5.1.0/configure ./configure
  cat > $TMPC << EOF
  #include <unistd.h>
  int main(void) {
-@@ -6074,7 +6085,8 @@
+@@ -6079,7 +6090,8 @@
  }
  EOF
  if compile_prog "" "" ; then


### PR DESCRIPTION
With signalfd=yes, QEMU 5.1 calls SYS_signalfd.
https://github.com/qemu/qemu/blob/17584289af1aaa72c932e7e47c25d583b329dc45/util/compatfd.c#L103

For some weird reason, Limbo ARMv7 version 5.0.0 makes signalfd system call instead of signalfd4.
But signalfd is outdated, only signalfd4 is whitelisted in SYSCALLS.TXT
https://android.googlesource.com/platform/bionic.git/+/master/libc/SYSCALLS.TXT#242

Therefore on devices where signalfd is forbidden it causes crash with "seccomp prevented call to disallowed arm system call 349" message.

Limbo 2.9.1 had this workaround, but Limbo 5.0 is missing it.
https://github.com/limboemu/limbo/blob/e94b0813f3b34a9200b95ba5ffdf3070379fe6f7/limbo-android-lib/src/main/jni/patches/qemu-2.9.1.patch#L108

And thank you for Limbo!