### PR TITLE
Hide navigation bar in SDL mode

### DIFF
--- a/limbo-android-lib/src/main/java/com/max2idea/android/limbo/main/LimboSDLActivity.java
+++ b/limbo-android-lib/src/main/java/com/max2idea/android/limbo/main/LimboSDLActivity.java
@@ -902,6 +902,15 @@ public class LimboSDLActivity extends SDLActivity {
 			getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
 					WindowManager.LayoutParams.FLAG_FULLSCREEN);
 
+			getWindow().getDecorView().setSystemUiVisibility(
+			   View.SYSTEM_UI_FLAG_LAYOUT_STABLE          // always use full screen
+			 | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION // overlayed navigation
+			 | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN      // overlayed status bar
+			 | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION        // hide navigation buttons
+			 | View.SYSTEM_UI_FLAG_FULLSCREEN             // hide status bar
+			 | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY       // keep navigation hidden
+			);
+
 		super.onCreate(savedInstanceState);
         setupVolume();
 
@@ -1772,6 +1781,16 @@ public class LimboSDLActivity extends SDLActivity {
 	//XXX: We want to suspend only when app is calling onPause()
 	@Override
 	public void onWindowFocusChanged(boolean hasFocus) {
+
+		if(hasFocus) // hide navigation only when using screen
+			getWindow().getDecorView().setSystemUiVisibility(
+			   View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+			 | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+			 | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+			 | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+			 | View.SYSTEM_UI_FLAG_FULLSCREEN
+			 | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+			);
 
 	}
 


### PR DESCRIPTION
@limboemu, you have already tried it in [SDLActivity.java](https://github.com/limboemu/limbo/blob/847f6063a0f62b70309c4f36602f68dca737e589/limbo-android-lib/src/main/java/org/libsdl/app/SDLActivity.java#L455L460), but it seemed to cause some problems.
Please try this variant, it seems to work.

And thank you for Limbo! :)