### PR TITLE
Is "~...+" characters handling still needed?

### DIFF
--- a/limbo-android-lib/src/main/java/android/androidVNC/VncCanvas.java
+++ b/limbo-android-lib/src/main/java/android/androidVNC/VncCanvas.java
@@ -1138,13 +1138,14 @@ public class VncCanvas extends AppCompatImageView {
 				//Log.v("unicode", "Unicode Char for " + evt.getKeyCode() + " is " + key);
 
                 //ΧΧΧ: Workaround for some chars not recognized by QEMU
-				int specialKey = isSpecialKey(key);
-				if (specialKey != -1) {
-					key = specialKey;
-                    metaState = metaState | VncCanvas.SHIFT_MASK;
-				} else if (keyCode >= 131 && keyCode <= 142) {
+		//		int specialKey = isSpecialKey(key);
+		//		if (specialKey != -1) {
+		//			key = specialKey;
+		//			metaState = metaState | VncCanvas.SHIFT_MASK;
+		//		} else
+				  if (keyCode >= 131 && keyCode <= 142) {
 					// Function Key pressed
-                    key = 0xFFBE + keyCode - 131;
+					key = 0xFFBE + keyCode - 131;
 				} else if (key == 0){
                     //Key is a meta combination or unknown
                     key = evt.getUnicodeChar(0);


### PR DESCRIPTION
QEMU in Limbo v4.1 and v5.0 seems to handle keys `!@#$%^&*()_+` etc. properly, removing the conversion doesn't seem to affect typing in guest OS.
But this conversion (to `1234567890-=`) prevents using these symbols in QEMU monitor – for example, you can not type commands "hostfwd_add" and "hostfwd_remove" (resulting in "hostfwd-add").
And thank you for Limbo!

P. s. I checked the behaviour only with "Hacker's keyboard".