### PR TITLE
More compatibility with Android 9…11

### DIFF
--- a/limbo-android-lib/src/main/AndroidManifest.xml
+++ b/limbo-android-lib/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
@@ -17,6 +18,10 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <uses-feature android:glEsVersion="0x00020000" />
-    
+    <application
+      android:requestLegacyExternalStorage="true"
+      android:usesCleartextTraffic="true"
+
+    </application>
 
 </manifest>


### PR DESCRIPTION
Android 10+ doesn't allow to use shared folder properly. These changes give Limbo requiring permissions.
Tested on Android 8, 10, 11.