### PR TITLE
Auto-calibrate external mouse only

### DIFF
--- a/limbo-android-lib/src/main/java/com/max2idea/android/limbo/main/LimboVNCActivity.java
+++ b/limbo-android-lib/src/main/java/com/max2idea/android/limbo/main/LimboVNCActivity.java
@@ -643,7 +643,8 @@ public class LimboVNCActivity extends VncCanvasActivity {
 		}
 
 		//Start calibration
-        calibration();
+		if (Config.mouseMode != Config.MouseMode.Trackpad)
+			calibration();
 
 		return true;
 	}


### PR DESCRIPTION
Current auto-calibration is a bit confusing. For example, you switch to QEMU monitor, then switch back to guest and mouse begin to run around the screen.
As a result:
1) mouse stops not in the place where you left it;
2) if phone is slow enough, sometimes mouse manages to click guest screen in several places during its movements.

Since in VNC mode there is a manual calibration in menu, is it possible to turn auto-calibration off?
For extetnal mouse, calibration probably works as it should, but I didn't test it.

And thank you for Limbo!