### PR TITLE
Please leave shared folder on

### DIFF
--- a/limbo-android-lib/src/main/java/com/max2idea/android/limbo/jni/VMExecutor.java
+++ b/limbo-android-lib/src/main/java/com/max2idea/android/limbo/jni/VMExecutor.java
@@ -577,13 +577,16 @@ private String getQemuLibrary() {
             paramsList.add("-drive"); //empty
             String driveParams = "index=3";
             driveParams += ",media=disk";
+            driveParams += ",snapshot=on";
             if (Config.enableIDEInterface) {
                 driveParams += ",if=";
                 driveParams += Config.ideInterfaceType;
             }
             driveParams += ",format=raw";
             driveParams += ",file=fat:";
-            driveParams += "rw:"; //Always Read/Write
+            // Mounting shared folder as read-only
+            // while allowing temporary writes with "snapshot=on"
+            //driveParams += "rw:"; //Always Read/Write
             driveParams += sharedFolderPath;
             paramsList.add(driveParams);
         }


### PR DESCRIPTION
@limboemu, in version 6 you have disabled shared folder feature. Please leave it on because it simplifies putting files into virtual machine a lot.

If crashes with shared folder are caused by guest OS writes, mounting SF read-only allows to use it without any problems.
Tested on Android 8 and 10.

However, to display files in shared folder on Android 11+, Limbo may need MANAGE_EXTERNAL_STORAGE permission and corresponding permission request code (PR https://github.com/limboemu/limbo/pull/132).

And thank you for Limbo! 🙂