### PR TITLE
Set accelerator options after user options

### DIFF
--- a/limbo-android-lib/src/main/java/com/max2idea/android/limbo/jni/VMExecutor.java
+++ b/limbo-android-lib/src/main/java/com/max2idea/android/limbo/jni/VMExecutor.java
@@ -167,6 +167,7 @@ private String getQemuLibrary() {
         addGenericOptions(context, paramsList);
         addStateOptions(paramsList);
         addAdvancedOptions(paramsList);
+        addAccelOptions(paramsList);
         return paramsList.toArray(new String[0]);
     }
 
@@ -346,7 +347,12 @@ private String getQemuLibrary() {
 
         paramsList.add("-m");
         paramsList.add(getMachine().getMemory() + "");
+    }
 
+    private void addAccelOptions(ArrayList<String> paramsList) {
+        //
+        //Set KVM or TCG accelerators options
+        //
         if (getMachine().getEnableKVM() != 0) {
             paramsList.add("-enable-kvm");
         } else {


### PR DESCRIPTION
@limboemu, in version 6.0 you changed TCG initialization options:
– in version 5.1, "-accel tcg,thread=multi" was added only if MTTCG was activated;
– in version 6.0, "-accel tcg" is added *always*, with "thread=multi" or "thread=single" option.

Although it ***is*** a better solution, because it allows to explicitly set single-threaded execution on 64-bit hosts, but now it's impossible to set additional TCG options in "Extra QEMU Params" field.

The reason is that in QEMU 5.1+, the TCG seems to be initialized only **once**, and all subsequent "-accel tcg" options are ignored.

After you're setting "-accel tcg" in Qemu 5.1, you can later write in extra options "-accel tcg,ANYTHING", options do not matter, they are skipped.
It makes impossible to set TCG buffer size with:
"-accel tcg<b>,tb-size=128</b>,thread=multi" or
"-accel tcg<b>,tb-size=128</b>,thread=single", for example.
The default size is convenient because it does not use much memory, but if machine does not need large RAM, it's possible to set more memory for TCG buffer, and then machine runs *noticeably smoother*.

The suggested solution is to set TCG options *after* user options – in that case user options will be set first and TCG will be initialized by them.
Or, if extra field is not set, TCG will be initialized as usual, with MTTCG checkbox.

It is compatible with QEMU 2.9.1, 5.1 and should be compatible with next versions.
And thank you for Limbo! :)