### PR TITLE
Load "main" before "qemu_init"

### DIFF
--- a/limbo-android-lib/src/main/jni/limbo/vm-executor-jni.c
+++ b/limbo-android-lib/src/main/jni/limbo/vm-executor-jni.c
@@ -184,10 +184,10 @@ JNIEXPORT jstring JNICALL Java_com_max2idea_android_limbo_jni_VMExecutor_start(
 	argv = (char **) malloc((argc + 1) * sizeof(*argv));
 
 	for (int i = 0; i < argc; i++) {
-        jstring string = (jstring)((*env)->GetObjectArrayElement(env, params, i));
+		jstring string = (jstring)((*env)->GetObjectArrayElement(env, params, i));
 		const char *param_str = (*env)->GetStringUTFChars(env, string, 0);
 		int length = strlen(param_str)+1;
-        argv[i] = (char *) malloc(length * sizeof(char));
+		argv[i] = (char *) malloc(length * sizeof(char));
 		strcpy(argv[i], param_str);
 		(*env)->ReleaseStringUTFChars(env, string, param_str);
 	}
@@ -196,15 +196,15 @@ JNIEXPORT jstring JNICALL Java_com_max2idea_android_limbo_jni_VMExecutor_start(
 	argv[argc] = NULL;
 
 	printf("Starting VM");
-    started = 1;
+	started = 1;
 
-    //LOAD LIB
+	//LOAD LIB
 	const char *lib_filename_str = NULL;
 	if (lib_filename!= NULL)
 		lib_filename_str = (*env)->GetStringUTFChars(env, lib_filename, 0);
-    const char *lib_path_str = NULL;
-    if (lib_path != NULL)
-        lib_path_str = (*env)->GetStringUTFChars(env, lib_path, 0);
+	const char *lib_path_str = NULL;
+	if (lib_path != NULL)
+	    lib_path_str = (*env)->GetStringUTFChars(env, lib_path, 0);
 
 	if (handle == NULL) {
 		handle = loadLib(lib_filename_str, lib_path_str);
@@ -217,14 +217,14 @@ JNIEXPORT jstring JNICALL Java_com_max2idea_android_limbo_jni_VMExecutor_start(
 	}
 
 	setup_jni(env, thiz, storage_dir, base_dir);
-    set_qemu_var(env, thiz, "limbo_sdl_scale_hint", sdl_scale_hint);
+	set_qemu_var(env, thiz, "limbo_sdl_scale_hint", sdl_scale_hint);
 
 	typedef void (*main_t)(int argc, char **argv, char **envp);
-    typedef void (*qemu_main_loop_t)();
+	typedef void (*qemu_main_loop_t)();
 	typedef void (*qemu_cleanup_t)();
 
-    qemu_main_loop_t qemu_main_loop = NULL;
-    qemu_cleanup_t qemu_cleanup = NULL;
+	qemu_main_loop_t qemu_main_loop = NULL;
+	qemu_cleanup_t qemu_cleanup = NULL;
 
 	dlerror();
 	main_t qemu_main = (main_t) dlsym(handle, "main");
@@ -246,9 +246,9 @@ JNIEXPORT jstring JNICALL Java_com_max2idea_android_limbo_jni_VMExecutor_start(
         	dlclose(handle);
         	handle = NULL;
         	return (*env)->NewStringUTF(env, dlsym_error);
-        }
+	    }
 
-        qemu_cleanup = (qemu_cleanup_t) dlsym(handle, "qemu_cleanup");
+	    qemu_cleanup = (qemu_cleanup_t) dlsym(handle, "qemu_cleanup");
 	    dlsym_error = dlerror();
 	    if (dlsym_error) {
         	LOGE("Cannot find qemu symbol 'qemu_cleanup': %s\n", dlsym_error);
@@ -269,11 +269,11 @@ JNIEXPORT jstring JNICALL Java_com_max2idea_android_limbo_jni_VMExecutor_start(
 	handle = NULL;
 	started = 0;
 
-    (*env)->ReleaseStringUTFChars(env, lib_path, lib_path_str);
+	(*env)->ReleaseStringUTFChars(env, lib_path, lib_path_str);
 
 	sprintf(res_msg, "VM shutdown");
 	LOGV("%s", res_msg);
-    return (*env)->NewStringUTF(env, res_msg);
+	return (*env)->NewStringUTF(env, res_msg);
 }
 
 

--- a/limbo-android-lib/src/main/jni/patches/qemu-5.1.0.patch
+++ b/limbo-android-lib/src/main/jni/patches/qemu-5.1.0.patch
@@ -574,3 +574,14 @@ diff -ru --no-dereference /tmp/qemu-5.1.0/util/qemu-openpty.c ./util/qemu-openpt
      return amaster;
  }
 +#endif
+diff -ru --no-dereference /tmp/qemu-5.1.0/softmmu/main.c ./softmmu/main.c
+--- /tmp/qemu-5.1.0/softmmu/main.c	2020-08-11 19:17:14.000000000 +0000
++++ ./softmmu/main.c	2023-05-04 00:09:58.595625144 +0000
+@@ -29,6 +29,7 @@
+ #ifdef CONFIG_SDL
+ #if defined(__APPLE__) || defined(main)
+ #include <SDL.h>
++#undef main
+ int main(int argc, char **argv)
+ {
+     return qemu_main(argc, argv, NULL);


### PR DESCRIPTION
As fix for "main" is not necessary since 6.0.1, this will avoid warning "Cannot find qemu symbol 'qemu_init'...".

**Upd.**
And to restore "main" symbol in QEMU, it seems enough to undefine it before declaring main().
(It's redefined to "SDL_main" somewhere in SDL header).

And thank you for Limbo!
P.s. And Happy Easter, by the way. 🙂