### PR TITLE
Fix "Could not create file" warning

### DIFF
--- a/limbo-android-lib/src/main/jni/compat/limbo_compat_filesystem.c
+++ b/limbo-android-lib/src/main/jni/compat/limbo_compat_filesystem.c
@@ -204,7 +204,7 @@ int android_mkstemp(char * path){
     strcat(lpath, path);
     int res = mkstemp(lpath);
     //printf("mkstemp limbo file: %s", path);
-    if(res)
+    if(-1 == res)
         LOGW("Could not create file: %s", lpath);
     return res;
 


### PR DESCRIPTION
When creating temporary files, Limbo warns that it can not make them because it treats mkstemp() handle as an error, although Limbo uses those files normally.
The erroneous response should be -1.

And thank you for Limbo! 🙂